### PR TITLE
Improve API key logging

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -13,7 +13,11 @@ const PORT = 3000;
 
 const GOVEE_API_KEY = process.env.GOVEE_API_KEY;
 const BASE_URL = "https://developer-api.govee.com/v1";
-console.log("Using Govee Key:", process.env.GOVEE_API_KEY);
+if (!GOVEE_API_KEY) {
+  console.error("Error: GOVEE_API_KEY is not defined. Please set it in your environment.");
+  process.exit(1);
+}
+console.log("Govee API key loaded");
 // Setup to understand JSON and serve files
 app.use(express.json());
 app.use(express.static(path.join(__dirname, "../frontend")));


### PR DESCRIPTION
## Summary
- avoid logging the GOVEE_API_KEY value
- exit early if GOVEE_API_KEY is missing

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68830463b410832db49ae057f7c1d155